### PR TITLE
Add aria-label attribute to fix the link-name-related 508 issues

### DIFF
--- a/src/pages/staticPages/datasetView/DatasetList.tsx
+++ b/src/pages/staticPages/datasetView/DatasetList.tsx
@@ -59,7 +59,13 @@ class CancerStudyCell extends React.Component<ICancerStudyCellProps, {}> {
 class ReferenceCell extends React.Component<IReferenceCellProps, {}> {
     render() {
         return (
-            <a target="_blank" href={getNCBIlink(`/pubmed/${this.props.pmid}`)}>
+            <a
+                target="_blank"
+                href={getNCBIlink(`/pubmed/${this.props.pmid}`)}
+                aria-label={
+                    this.props.citation ? undefined : 'No Reference Link'
+                }
+            >
                 {' '}
                 {this.props.citation}{' '}
             </a>

--- a/src/shared/components/StudyDataDownloadLink/StudyDataDownloadLink.tsx
+++ b/src/shared/components/StudyDataDownloadLink/StudyDataDownloadLink.tsx
@@ -10,6 +10,7 @@ export class StudyDataDownloadLink extends React.Component<
         return (
             <a
                 className="dataset-table-download-link"
+                aria-label={`Download Study ${this.props.studyId}`}
                 style={{ display: 'block' }}
                 href={getStudyDownloadUrl() + this.props.studyId + '.tar.gz'}
                 download


### PR DESCRIPTION
This PR adds "aria-label" attribute to Anchor tag to improve 508 compliance.