### PR TITLE
feat(build): generate version.json from CBIOPORTAL_VERSION

### DIFF
--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -2,22 +2,29 @@
 const fs = require('fs');
 const path = require('path');
 
-try {
-    // Read the file and extract CBIOPORTAL_VERSION using a regex
+function readFromEnv() {
+    return (
+        process.env.CBIOPORTAL_VERSION && process.env.CBIOPORTAL_VERSION.trim()
+    );
+}
+
+function readFromMasterSh() {
     const pathToEnv = path.join(__dirname, '..', 'env', 'master.sh');
     if (!fs.existsSync(pathToEnv)) {
         throw new Error(`Environment file not found: ${pathToEnv}`);
     }
-
     const envContent = fs.readFileSync(pathToEnv, 'utf8');
     const match = envContent.match(
         /^\s*export\s+CBIOPORTAL_VERSION\s*=\s*["']?\$\{CBIOPORTAL_VERSION:-([^}"']+)/m
     );
-    const version = match ? match[1].trim() : 'unknown';
-    const data = { version };
+    return match ? match[1].trim() : null;
+}
+
+try {
+    const version = readFromEnv() || readFromMasterSh() || 'unknown';
 
     const outFile = path.join(__dirname, '..', 'version.json');
-    fs.writeFileSync(outFile, JSON.stringify(data, null, 2));
+    fs.writeFileSync(outFile, JSON.stringify({ version }, null, 2));
 } catch (error) {
     console.error('Error retrieving CBIOPORTAL_VERSION:', error);
 }


### PR DESCRIPTION
This pull request refactors the logic for retrieving the `CBIOPORTAL_VERSION` in the `scripts/generate-version.js` script. The main improvement is that the script now first checks for the version in the environment variables before falling back to reading it from the `master.sh` file, making it more flexible and robust.

Version retrieval logic improvements:

* Added a new `readFromEnv` function to check for `CBIOPORTAL_VERSION` in the environment variables before reading from the `master.sh` file.
* Refactored the script to use the new `readFromEnv` and `readFromMasterSh` functions, simplifying the version extraction and fallback logic.