### PR TITLE
Open the URL without header

### DIFF
--- a/src/shared/api/urls.ts
+++ b/src/shared/api/urls.ts
@@ -151,7 +151,12 @@ export function getResourceViewUrlWithPathname(
     patientId: string
 ) {
     let caseId: string = `${patientId}`;
-    return buildCBioPortalPageUrl(pathname, { studyId, caseId });
+    return buildCBioPortalPageUrl(
+        pathname,
+        { studyId, caseId },
+        undefined,
+        false
+    );
 }
 
 export function getPatientViewUrl(


### PR DESCRIPTION
This pull request updates the `getResourceViewUrlWithPathname` function in `src/shared/api/urls.ts` to change how it calls `buildCBioPortalPageUrl`. The update adds new arguments to the function call, which may affect how URLs are generated for resource views.

Changes to URL generation logic:

* Updated the call to `buildCBioPortalPageUrl` in `getResourceViewUrlWithPathname` to include two additional arguments: `undefined` and `false`, potentially modifying the behavior of the generated URLs.