### PR TITLE
Hide iframe if the link is from ccdi

### DIFF
--- a/src/shared/components/iframeLoader/IFrameLoader.tsx
+++ b/src/shared/components/iframeLoader/IFrameLoader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ThreeBounce } from 'better-react-spinkit';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
 import { observer } from 'mobx-react';
-import { computed, makeObservable, observable } from 'mobx';
+import { makeObservable, observable } from 'mobx';
 import autobind from 'autobind-decorator';
 import FontAwesome from 'react-fontawesome';
 interface FrameLoaderProps {
@@ -11,6 +11,7 @@ interface FrameLoaderProps {
     iframeId?: string;
     height?: number | string;
     width?: number | string;
+    includeCcdiLinks?: boolean;
 }
 @observer
 export default class IFrameLoader extends React.Component<
@@ -33,16 +34,6 @@ export default class IFrameLoader extends React.Component<
         this.iframeLoaded = true;
     }
 
-    @computed get includeCcdiLinks() {
-        // Matches ccdi.cancer.gov with optional subdomains, case-insensitive
-        const re = /^(https?:\/\/)?([\w-]+\.)*ccdi\.cancer\.gov(\/|$)/i;
-        try {
-            return re.test(this.props.url);
-        } catch {
-            return false;
-        }
-    }
-
     //NOTE: we need zindex to be higher than that of global loader
     render() {
         return (
@@ -56,7 +47,9 @@ export default class IFrameLoader extends React.Component<
                 <LoadingIndicator
                     center={true}
                     size={'big'}
-                    isLoading={!this.iframeLoaded && !this.includeCcdiLinks}
+                    isLoading={
+                        !this.iframeLoaded && !this.props.includeCcdiLinks
+                    }
                 />
                 <a
                     href={this.props.url}
@@ -70,7 +63,7 @@ export default class IFrameLoader extends React.Component<
                 >
                     Open in new window <FontAwesome name="external-link" />
                 </a>
-                {!this.includeCcdiLinks && (
+                {!this.props.includeCcdiLinks && (
                     <iframe
                         id={this.props.iframeId || ''}
                         className={this.props.className || ''}

--- a/src/shared/components/iframeLoader/IFrameLoader.tsx
+++ b/src/shared/components/iframeLoader/IFrameLoader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ThreeBounce } from 'better-react-spinkit';
 import LoadingIndicator from '../loadingIndicator/LoadingIndicator';
 import { observer } from 'mobx-react';
-import { makeObservable, observable } from 'mobx';
+import { computed, makeObservable, observable } from 'mobx';
 import autobind from 'autobind-decorator';
 import FontAwesome from 'react-fontawesome';
 interface FrameLoaderProps {
@@ -33,6 +33,16 @@ export default class IFrameLoader extends React.Component<
         this.iframeLoaded = true;
     }
 
+    @computed get includeCcdiLinks() {
+        // Matches ccdi.cancer.gov with optional subdomains, case-insensitive
+        const re = /^(https?:\/\/)?([\w-]+\.)*ccdi\.cancer\.gov(\/|$)/i;
+        try {
+            return re.test(this.props.url);
+        } catch {
+            return false;
+        }
+    }
+
     //NOTE: we need zindex to be higher than that of global loader
     render() {
         return (
@@ -46,7 +56,7 @@ export default class IFrameLoader extends React.Component<
                 <LoadingIndicator
                     center={true}
                     size={'big'}
-                    isLoading={!this.iframeLoaded}
+                    isLoading={!this.iframeLoaded && !this.includeCcdiLinks}
                 />
                 <a
                     href={this.props.url}
@@ -60,21 +70,23 @@ export default class IFrameLoader extends React.Component<
                 >
                     Open in new window <FontAwesome name="external-link" />
                 </a>
-                <iframe
-                    id={this.props.iframeId || ''}
-                    className={this.props.className || ''}
-                    style={{
-                        width: '100%',
-                        position: 'relative',
-                        zIndex: 100,
-                        height: this.props.height,
-                        border: 'none',
-                        marginTop: 5,
-                    }}
-                    src={this.props.url}
-                    onLoad={this.onLoad}
-                    allowFullScreen={true}
-                ></iframe>
+                {!this.includeCcdiLinks && (
+                    <iframe
+                        id={this.props.iframeId || ''}
+                        className={this.props.className || ''}
+                        style={{
+                            width: '100%',
+                            position: 'relative',
+                            zIndex: 100,
+                            height: this.props.height,
+                            border: 'none',
+                            marginTop: 5,
+                        }}
+                        src={this.props.url}
+                        onLoad={this.onLoad}
+                        allowFullScreen={true}
+                    ></iframe>
+                )}
             </div>
         );
     }

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -110,6 +110,16 @@ export default class ResourceTab extends React.Component<
         return url;
     }
 
+    @computed get includeCcdiLinks() {
+        // Matches ccdi.cancer.gov with optional subdomains, case-insensitive
+        const re = /^(https?:\/\/)?([\w-]+\.)*ccdi\.cancer\.gov(\/|$)/i;
+        try {
+            return re.test(this.iframeUrl);
+        } catch {
+            return false;
+        }
+    }
+
     render() {
         const multipleData = this.props.resourceData.length > 1;
 
@@ -137,7 +147,7 @@ export default class ResourceTab extends React.Component<
                 <div
                     style={{
                         width: '100%',
-                        height: this.iframeHeight,
+                        height: this.includeCcdiLinks ? 0 : this.iframeHeight,
                         display: 'flex',
                         alignItems: 'center',
                     }}

--- a/src/shared/components/resources/ResourceTab.tsx
+++ b/src/shared/components/resources/ResourceTab.tsx
@@ -181,6 +181,7 @@ export default class ResourceTab extends React.Component<
                             url={this.iframeUrl}
                             height={this.iframeHeight}
                             width={'100%'}
+                            includeCcdiLinks={this.includeCcdiLinks}
                         />
                     )}
                     {multipleData && (


### PR DESCRIPTION
This pull request improves how CCDI (ccdi.cancer.gov) links are handled in the iframe loader and resource tab components. The main change is that if the loaded URL matches the CCDI domain, the iframe is not rendered and the loading indicator is suppressed, providing a more appropriate user experience for these links.

**CCDI Link Handling**

* Added a computed property `includeCcdiLinks` in both `IFrameLoader` and `ResourceTab` components to detect CCDI URLs using a case-insensitive regex. [[1]](diffhunk://#diff-187de24cd0619e3422beae9fece280ae45ae2aca69d8b6945ee899b0c877dac4R36-R45) [[2]](diffhunk://#diff-e9bbf9c9a92e11326e7fa2ff8d97edf1c735a3d8f8a1b992530971e2ffb85d78R113-R122)
* Updated the rendering logic in `IFrameLoader` to suppress the loading indicator and prevent rendering the iframe for CCDI links. [[1]](diffhunk://#diff-187de24cd0619e3422beae9fece280ae45ae2aca69d8b6945ee899b0c877dac4L49-R59) [[2]](diffhunk://#diff-187de24cd0619e3422beae9fece280ae45ae2aca69d8b6945ee899b0c877dac4R73) [[3]](diffhunk://#diff-187de24cd0619e3422beae9fece280ae45ae2aca69d8b6945ee899b0c877dac4R89)
* Modified the container height in `ResourceTab` to be zero when displaying CCDI links, effectively hiding the iframe area.

**Dependency Updates**

* Added `computed` import from `mobx` in `IFrameLoader.tsx` to support the new computed property.