### PR TITLE
Replace Link with anchor tag using absolute URLs

### DIFF
--- a/src/shared/components/StudyLink/StudyLink.tsx
+++ b/src/shared/components/StudyLink/StudyLink.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { buildCBioPortalPageUrl } from '../../../shared/api/urls';
+import { buildCBioPortalPageUrl } from '../../api/urls';
 
 type StudyLinkProps = {
     studyId: string;
@@ -32,13 +32,17 @@ class StudyLinkComponent extends React.Component<
         const absoluteStudyUrl = buildCBioPortalPageUrl('study', {
             id: this.props.studyId,
         });
+        const anchorAriaLabel =
+            this.props.studyName && !this.props.children
+                ? `Open the study summary page for ${this.props.studyName}.`
+                : undefined;
 
         return (
             <a
                 href={absoluteStudyUrl}
                 className={this.props.className}
                 onClick={this.handleClick}
-                aria-label={`Open the study summary page for ${this.props.studyName} in a new tab`}
+                aria-label={anchorAriaLabel}
             >
                 {this.props.children}
             </a>

--- a/src/shared/components/StudyLink/StudyLink.tsx
+++ b/src/shared/components/StudyLink/StudyLink.tsx
@@ -1,24 +1,49 @@
 import * as React from 'react';
-import { CancerStudy } from 'cbioportal-ts-api-client';
-import { Link } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { buildCBioPortalPageUrl } from '../../../shared/api/urls';
 
-export class StudyLink extends React.Component<
-    {
-        studyId: string;
-        className?: string;
-        studyName?: string;
-    },
+type StudyLinkProps = {
+    studyId: string;
+    className?: string;
+    studyName?: string;
+};
+
+class StudyLinkComponent extends React.Component<
+    StudyLinkProps & RouteComponentProps,
     {}
 > {
+    private handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+        if (
+            event.defaultPrevented ||
+            event.button !== 0 ||
+            event.metaKey ||
+            event.altKey ||
+            event.ctrlKey ||
+            event.shiftKey
+        ) {
+            return;
+        }
+
+        event.preventDefault();
+        this.props.history.push(`/study?id=${this.props.studyId}`);
+    };
+
     render() {
+        const absoluteStudyUrl = buildCBioPortalPageUrl('study', {
+            id: this.props.studyId,
+        });
+
         return (
-            <Link
-                to={`/study?id=${this.props.studyId}`}
+            <a
+                href={absoluteStudyUrl}
                 className={this.props.className}
+                onClick={this.handleClick}
                 aria-label={`Open the study summary page for ${this.props.studyName} in a new tab`}
             >
                 {this.props.children}
-            </Link>
+            </a>
         );
     }
 }
+
+export const StudyLink = withRouter(StudyLinkComponent);


### PR DESCRIPTION
This pull request refactors the `StudyLink` component to improve routing and URL handling. The main changes include replacing the use of the `Link` component with a custom anchor tag that handles navigation programmatically, and generating absolute URLs for study pages.

**Component refactor and routing improvements:**

* Replaced the `Link` component from `react-router-dom` with a custom `<a>` tag that uses a click handler to programmatically push to the study route, ensuring proper SPA navigation and improved control over link behavior.
* Added the use of `withRouter` and `RouteComponentProps` to access the router’s history object for navigation.

**URL construction enhancement:**

* Utilized the `buildCBioPortalPageUrl` utility to generate absolute URLs for study links, improving consistency and maintainability of URL construction.