### PR TITLE
Comment out CUSTOM_DATA tab temporarily

### DIFF
--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -932,7 +932,10 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         key={3}
                         id={ChartMetaDataTypeEnum.CUSTOM_DATA}
                         linkText={TabNamesEnum.CUSTOM_DATA}
-                        hide={true}
+                        hide={
+                            this.props.defaultActiveTab !==
+                            ChartMetaDataTypeEnum.CUSTOM_DATA
+                        }
                         className="custom"
                     >
                         <div

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -933,8 +933,9 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         id={ChartMetaDataTypeEnum.CUSTOM_DATA}
                         linkText={TabNamesEnum.CUSTOM_DATA}
                         hide={
+                            !!this.props.disableCustomTab ||
                             this.props.defaultActiveTab !==
-                            ChartMetaDataTypeEnum.CUSTOM_DATA
+                                ChartMetaDataTypeEnum.CUSTOM_DATA
                         }
                         className="custom"
                     >

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -927,7 +927,8 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                             </div>
                         )}
                     </MSKTab>
-                    <MSKTab
+                    {/* TODO: Uncomment out the following tab once we have the authentication & authorization ready */}
+                    {/* <MSKTab
                         key={3}
                         id={ChartMetaDataTypeEnum.CUSTOM_DATA}
                         linkText={TabNamesEnum.CUSTOM_DATA}
@@ -1089,7 +1090,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                 </div>
                             )}
                         </div>
-                    </MSKTab>
+                    </MSKTab> */}
                     {!this.props.disableVariantAnnotationsTab &&
                         this.variantAnnotationsTab}
                     <MSKTab

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -927,12 +927,12 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                             </div>
                         )}
                     </MSKTab>
-                    {/* Set hide to true temporarily. Re-enable when ready. (hide={this.props.disableCustomTab}) */}
-                    <MSKTab
+                    {/* TODO: Uncomment when authentication & authorization is ready. */}
+                    {/* <MSKTab
                         key={3}
                         id={ChartMetaDataTypeEnum.CUSTOM_DATA}
                         linkText={TabNamesEnum.CUSTOM_DATA}
-                        hide={true}
+                        hide={this.props.disableCustomTab}
                         className="custom"
                     >
                         <div
@@ -1090,7 +1090,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                 </div>
                             )}
                         </div>
-                    </MSKTab>
+                    </MSKTab> */}
                     {!this.props.disableVariantAnnotationsTab &&
                         this.variantAnnotationsTab}
                     <MSKTab

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -932,11 +932,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                         key={3}
                         id={ChartMetaDataTypeEnum.CUSTOM_DATA}
                         linkText={TabNamesEnum.CUSTOM_DATA}
-                        hide={
-                            !!this.props.disableCustomTab ||
-                            this.props.defaultActiveTab !==
-                                ChartMetaDataTypeEnum.CUSTOM_DATA
-                        }
+                        hide={true}
                         className="custom"
                     >
                         <div

--- a/src/pages/studyView/addChartButton/AddChartButton.tsx
+++ b/src/pages/studyView/addChartButton/AddChartButton.tsx
@@ -927,12 +927,12 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                             </div>
                         )}
                     </MSKTab>
-                    {/* TODO: Uncomment out the following tab once we have the authentication & authorization ready */}
-                    {/* <MSKTab
+                    {/* Set hide to true temporarily. Re-enable when ready. (hide={this.props.disableCustomTab}) */}
+                    <MSKTab
                         key={3}
                         id={ChartMetaDataTypeEnum.CUSTOM_DATA}
                         linkText={TabNamesEnum.CUSTOM_DATA}
-                        hide={this.props.disableCustomTab}
+                        hide={true}
                         className="custom"
                     >
                         <div
@@ -1090,7 +1090,7 @@ class AddChartTabs extends React.Component<IAddChartTabsProps, {}> {
                                 </div>
                             )}
                         </div>
-                    </MSKTab> */}
+                    </MSKTab>
                     {!this.props.disableVariantAnnotationsTab &&
                         this.variantAnnotationsTab}
                     <MSKTab


### PR DESCRIPTION
This pull request makes a minor update to the `AddChartTabs` component in `AddChartButton.tsx`. Specifically, it comments out the "Custom Data" tab, with a note indicating that this tab will be re-enabled once authentication and authorization are implemented.

* UI Update:
  * Commented out the `MSKTab` for `CUSTOM_DATA` in `AddChartTabs`, adding a TODO note to re-enable it after authentication and authorization are ready. [[1]](diffhunk://#diff-2c76ee08342f5cf09e54594c2c9ea1b268689a000376f4b1e1e76d2f9fb048f5L930-R931) [[2]](diffhunk://#diff-2c76ee08342f5cf09e54594c2c9ea1b268689a000376f4b1e1e76d2f9fb048f5L1092-R1093)